### PR TITLE
Use "defacto standard" for unread notifications in page title

### DIFF
--- a/app/assets/javascripts/sugar/posts/new_posts.js.coffee
+++ b/app/assets/javascripts/sugar/posts/new_posts.js.coffee
@@ -80,7 +80,7 @@ $(Sugar).bind 'ready', ->
   # Update the window title on new posts
   original_document_title = document.title
   $(Sugar).bind 'newposts', (event, total_posts, new_posts, unread_posts) ->
-    document.title = "[#{unread_posts} new posts] #{original_document_title}"
+    document.title = "(#{unread_posts}) #{original_document_title}"
 
   # Reset the document title when posts are loaded
   $(Sugar).bind 'postsloaded', ->


### PR DESCRIPTION
Change the page title notification of new posts to use "(#)" instead of "[# new posts]" to conform to the defacto standard used by Facebook, Twitter, StackExchange, etc.

This suggestion is mostly borne of my love for silly browser extensions which inject the notification count into the tab where the title may not be visible.
