### PR TITLE
Previous Username History

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,10 @@ class User < ActiveRecord::Base
     (self[:moderator] || admin?)
   end
 
+  def previous_usernames
+    self[:previous_usernames].split("\n")
+  end
+
   # Returns admin flags as strings
   def admin_labels
     labels = []
@@ -127,15 +131,10 @@ class User < ActiveRecord::Base
         self.admin = true
       end
     end
+
     def check_username_change
-      if self.changed_attributes[:username]
-        if self.previous_usernames
-          prev_usernames = self.previous_usernames.split
-        else
-          prev_usernames = []
-        end
-        prev_usernames << self.changed_attributes[:username]
-        self.previous_usernames = prev_usernames.join(',')
+      if self.username_changed?
+        self[:previous_usernames] = ([self.username_was] + previous_usernames).join("\n")
       end
     end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -40,8 +40,8 @@
   <div class="previous_usernames">
     <b>Previously Known As:</b>
     <ul>
-    <% @user.previous_usernames.split(',').each do |prev_names| %>
-      <li><%= prev_names %></li>
+    <% @user.previous_usernames.each do |username| %>
+      <li><%= username %></li>
     <% end %>
     </ul>
   </div>

--- a/app/views/users/show.mobile.erb
+++ b/app/views/users/show.mobile.erb
@@ -98,8 +98,8 @@
       <th>Previously Known As</th>
       <td>
         <ul>
-        <% @user.previous_usernames.split(',').each do |prev_names| %>
-          <li><%= prev_names %></li><% end %>
+        <% @user.previous_usernames.each do |username| %>
+          <li><%= username %></li><% end %>
         </ul>
       </td>
     </tr><% end %>

--- a/db/migrate/20141214074344_add_previous_usernames_to_users.rb
+++ b/db/migrate/20141214074344_add_previous_usernames_to_users.rb
@@ -1,5 +1,5 @@
 class AddPreviousUsernamesToUsers < ActiveRecord::Migration
   def change
-  	add_column :users, :previous_usernames, :text
+  	add_column :users, :previous_usernames, :text, default: '', null: false
   end
 end


### PR DESCRIPTION
On changing a username, keep a list of old usernames. 
Old names are displayed on user profiles.

Might not be the prettiest way of doing this...
