### PR TITLE
Improve performance by embedding imgur GIFs as MP4 video files.

### DIFF
--- a/app/filters/autolink_filter.rb
+++ b/app/filters/autolink_filter.rb
@@ -15,6 +15,8 @@ class AutolinkFilter < Filter
   def autolink(url)
     if url =~ /\.(jpg|jpeg|gif|png)$/i
       "<img src=\"#{url}\">"
+    elsif url =~ /\.(gifv)$/i
+      "<video loop controls autoplay><source src=\"" + url.sub(/\.gifv/, '.mp4') + "\" type=\"video/mp4\"></video>"
     else
       "<a href=\"#{url}\">#{url}</a>"
     end

--- a/app/filters/autolink_filter.rb
+++ b/app/filters/autolink_filter.rb
@@ -13,7 +13,9 @@ class AutolinkFilter < Filter
   private
 
   def autolink(url)
-    if url =~ /\.(jpg|jpeg|gif|png)$/i
+    if url =~ /imgur.*\.(gif)$/i
+      "<video loop controls autoplay><source src=\"" + url.sub(/\.gif/, '.mp4') + "\" type=\"video/mp4\"></video>"
+    elsif url =~ /.(jpg|jpeg|gif|png)$/i
       "<img src=\"#{url}\">"
     elsif url =~ /\.(gifv)$/i
       "<video loop controls autoplay><source src=\"" + url.sub(/\.gifv/, '.mp4') + "\" type=\"video/mp4\"></video>"

--- a/spec/filters/autolink_filter_spec.rb
+++ b/spec/filters/autolink_filter_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe AutolinkFilter do
+
+  it "embeds jpgs and pngs properly" do
+    expect(AutolinkFilter.new("http://random.com/folder/folder/file.png").to_html).to eq("<img src=\"http://random.com/folder/folder/file.png\">")
+  end
+
+  it "embeds imgur gifs as mp4 video properly" do
+    expect(AutolinkFilter.new("http://i.imgur.com/abcdefg.gif").to_html).to eq("<video loop controls autoplay><source src=\"http://i.imgur.com/abcdefg.mp4\" type=\"video/mp4\"></video>")
+  end
+
+  it "embeds imgur gifvs as mp4 video properly" do
+    expect(AutolinkFilter.new("http://i.imgur.com/abcdefg.gifv").to_html).to eq("<video loop controls autoplay><source src=\"http://i.imgur.com/abcdefg.mp4\" type=\"video/mp4\"></video>")
+  end
+
+
+end


### PR DESCRIPTION
This might need to be implemented at the client level to allow mobile to keep using GIFs, or maybe it's better to have them use <video> to reduce traffic?