### PR TITLE
Clean up the user profiles a bit more, and add Battle.net tag.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -145,7 +145,7 @@ class UsersController < ApplicationController
       :mobile_theme, :msn, :notify_on_message, :realname,
       :stylesheet_url, :theme, :time_zone, :twitter, :website,
       :password, :confirm_password, :banned_until, :preferred_format,
-      :sony, :nintendo, :steam,
+      :sony, :nintendo, :steam, :battlenet,
       avatar_attributes: [:file]
     ]
     if current_user?

--- a/app/models/concerns/user_scopes.rb
+++ b/app/models/concerns/user_scopes.rb
@@ -42,7 +42,8 @@ module UserScopes
         "(gamertag IS NOT NULL AND gamertag != '') " +
         "OR (sony IS NOT NULL AND sony != '') " +
         "OR (nintendo IS NOT NULL AND nintendo != '') " +
-        "OR (steam IS NOT NULL AND steam != '')"
+        "OR (steam IS NOT NULL AND steam != '')" +
+        "OR (battlenet IS NOT NULL AND battlenet != '')"
       )
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,7 +116,7 @@ class User < ActiveRecord::Base
       :moderator, :user_admin,
       :location, :gamertag, :twitter, :flickr, :instagram, :website,
       :msn, :gtalk, :last_fm, :facebook_uid, :banned_until,
-      :sony, :nintendo, :steam
+      :sony, :nintendo, :steam, :battlenet
     ]
   end
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -3,7 +3,7 @@ class UserSerializer < ActiveModel::Serializer
   attributes :last_active, :created_at, :description, :admin
   attributes :moderator, :user_admin
   attributes :location, :gamertag, :twitter, :flickr, :instagram, :website
-  attributes :sony, :nintendo, :steam
+  attributes :sony, :nintendo, :steam, :battlenet
   attributes :msn, :gtalk, :last_fm, :facebook_uid, :banned_until
 
   attributes :active, :banned

--- a/app/views/users/_edit_services.html.erb
+++ b/app/views/users/_edit_services.html.erb
@@ -10,11 +10,15 @@
   </p>
 <% end %>
 
-<fieldset id="social_media">
-  <h2><%= t('user.edit.social_media') %></h2>
+<fieldset id="messaging">
+  <h2><%= t('user.edit.messaging') %></h2>
   <%= f.labelled_text_field :gtalk %>
   <%= f.labelled_text_field :msn %>
   <%= f.labelled_text_field :aim %>
+</fieldset>
+
+<fieldset id="social_media">
+  <h2><%= t('user.edit.social_media') %></h2>
   <%= f.labelled_text_field :twitter %>
   <%= f.labelled_text_field :flickr, description: t('user.edit.flickr_description') %>
   <%= f.labelled_text_field :last_fm %>
@@ -27,4 +31,5 @@
   <%= f.labelled_text_field :sony %>
   <%= f.labelled_text_field :nintendo %>
   <%= f.labelled_text_field :steam %>
+  <%= f.labelled_text_field :battlenet %>
 </fieldset>

--- a/app/views/users/_users_listing.html.erb
+++ b/app/views/users/_users_listing.html.erb
@@ -26,6 +26,8 @@
         "Nintendo ID"
       when :steam
         "Steam ID"
+      when :battlenet
+        "Battle.net"
       else
         column.to_s.humanize
       end
@@ -71,9 +73,11 @@
       when :sony
         link_to(user.sony, "http://us.playstation.com/playstation/psn/visit/profiles/#{user.sony}") if user.sony?
       when :nintendo
-        link_to(user.nintendo, "http://miiverse.nintendo.com/users/#{user.nintendo}") if user.nintendo?
+        link_to(user.nintendo, "https://miiverse.nintendo.net/users/#{user.nintendo}") if user.nintendo?
       when :steam
         link_to(user.steam, "http://steamcommunity.com/id/#{user.steam}") if user.steam?
+      when :battlenet
+        user.battlenet if user.battlenet?
       else
         "#{column} not defined"
       end

--- a/app/views/users/gaming.html.erb
+++ b/app/views/users/gaming.html.erb
@@ -14,4 +14,4 @@
 
 <%= render partial: 'list_navigation' %>
 
-<%= render partial: 'users_listing', locals: {users: @users, columns: [:username, :gamertag, :sony, :nintendo, :steam]} %>
+<%= render partial: 'users_listing', locals: {users: @users, columns: [:username, :gamertag, :sony, :nintendo, :steam, :battlenet]} %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -132,7 +132,7 @@
     </div>
   <% end %>
 
-  <% if @user.gamertag? || @user.sony? || @user.nintendo? || @user.steam? %>
+  <% if @user.gamertag? || @user.sony? || @user.nintendo? || @user.steam? || @user.battlenet %>
     <div class="social gaming">
       <% if @user.gamertag? %>
         <strong>Xbox Live:</strong>
@@ -150,7 +150,7 @@
       <% end %>
       <% if @user.nintendo? %>
         <strong>Nintendo ID:</strong>
-        <a href="http://miiverse.nintendo.com/users/<%= @user.nintendo %>">
+        <a href="https://miiverse.nintendo.net/users/<%= @user.nintendo %>">
           <%= @user.nintendo %>
         </a>
         <br />
@@ -160,6 +160,11 @@
         <a href="http://steamcommunity.com/id/<%= @user.steam %>">
           <%= @user.steam %>
         </a>
+        <br />
+      <% end %>
+      <% if @user.steam? %>
+        <strong>Battle.net:</strong>
+        <%= @user.battlenet %>
         <br />
       <% end %>
     </div>

--- a/app/views/users/show.mobile.erb
+++ b/app/views/users/show.mobile.erb
@@ -73,6 +73,10 @@
       <th>Steam ID</th>
       <td><%= @user.steam %></td>
     </tr><% end %>
+    <% if @user.battlenet? %><tr>
+      <th>Battle.net BattleTag</th>
+      <td><%= @user.battlenet %></td>
+    </tr><% end %>
     <% if @user.inviter %><tr>
       <th>Invited by</th>
       <td><%= profile_link(@user.inviter) %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
         sony: PlayStation username
         nintendo: Nintendo ID
         steam: Steam ID
+        battlenet: Battle.net BattleTag
         twitter: Twitter username
         flickr: Flickr user ID
         last_fm: Last.fm username
@@ -116,6 +117,7 @@ en:
       chosen_a_time_zone: chosen a time zone
       gaming: Gaming
       social_media: Social Media
+      messaging: Messaging
     new:
       openid_description: "<a href=\"http://openid.net/what/\">What's this?"
       optional_fields: "The following fields are optional, but it's always nice to provide a bit more information:"

--- a/db/migrate/20150322093615_add_battlenet_to_user.rb
+++ b/db/migrate/20150322093615_add_battlenet_to_user.rb
@@ -1,0 +1,5 @@
+class AddBattlenetToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :battlenet, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150221190042) do
+ActiveRecord::Schema.define(version: 20150322093615) do
 
   create_table "avatars", force: :cascade do |t|
     t.string   "content_hash",   limit: 255
@@ -99,7 +99,7 @@ ActiveRecord::Schema.define(version: 20150221190042) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "last_post_at"
-    t.string   "type",           limit: 100
+    t.string   "type",           limit: 255
   end
 
   add_index "exchanges", ["created_at"], name: "created_at_index", using: :btree
@@ -108,7 +108,7 @@ ActiveRecord::Schema.define(version: 20150221190042) do
   add_index "exchanges", ["sticky", "last_post_at"], name: "index_exchanges_on_sticky_and_last_post_at", using: :btree
   add_index "exchanges", ["sticky"], name: "sticky_index", using: :btree
   add_index "exchanges", ["trusted"], name: "trusted_index", using: :btree
-  add_index "exchanges", ["type"], name: "index_exchanges_on_type", using: :btree
+  add_index "exchanges", ["type"], name: "index_exchanges_on_type", length: {"type"=>191}, using: :btree
 
   create_table "invites", force: :cascade do |t|
     t.integer  "user_id",    limit: 4
@@ -152,11 +152,11 @@ ActiveRecord::Schema.define(version: 20150221190042) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "owner_id",     limit: 4
-    t.string   "owner_type",   limit: 100
+    t.string   "owner_type",   limit: 255
     t.string   "scopes",       limit: 255, default: "", null: false
   end
 
-  add_index "oauth_applications", ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", using: :btree
+  add_index "oauth_applications", ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type", length: {"owner_id"=>nil, "owner_type"=>191}, using: :btree
 
   create_table "password_reset_tokens", force: :cascade do |t|
     t.integer  "user_id",    limit: 4
@@ -191,7 +191,7 @@ ActiveRecord::Schema.define(version: 20150221190042) do
   add_index "posts", ["user_id"], name: "index_posts_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "username",              limit: 100
+    t.string   "username",              limit: 255
     t.string   "realname",              limit: 255
     t.string   "email",                 limit: 255
     t.string   "hashed_password",       limit: 255
@@ -241,9 +241,10 @@ ActiveRecord::Schema.define(version: 20150221190042) do
     t.text     "previous_usernames",    limit: 65535
     t.string   "nintendo",              limit: 255
     t.string   "steam",                 limit: 255
+    t.string   "battlenet",             limit: 255
   end
 
   add_index "users", ["last_active"], name: "last_active_index", using: :btree
-  add_index "users", ["username"], name: "username_index", using: :btree
+  add_index "users", ["username"], name: "username_index", length: {"username"=>191}, using: :btree
 
 end

--- a/spec/models/concerns/user_scopes_spec.rb
+++ b/spec/models/concerns/user_scopes_spec.rb
@@ -63,8 +63,9 @@ describe UserScopes do
     let!(:sony) { create(:user, sony: "example") }
     let!(:nintendo) { create(:user, nintendo: "example") }
     let!(:steam) { create(:user, steam: "example") }
+    let!(:battlenet) { create(:user, battlenet: "example#1234") }
     subject { User.gaming }
-    it { is_expected.to match_array([gamertag, sony, nintendo, steam]) }
+    it { is_expected.to match_array([gamertag, sony, nintendo, steam, battlenet]) }
   end
 
   describe "recently_joined" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,7 @@ describe User do
       "inviter_id", "last_active", "last_fm", "latitude", "location",
       "longitude", "moderator", "msn", "realname", "twitter", "user_admin",
       "username", "website", "active", "banned",
-      "sony", "nintendo", "steam"
+      "sony", "nintendo", "steam", "battlenet"
     ]
   end
 


### PR DESCRIPTION
Add a "messaging" category to the "links and services" editing page.

Add Battle.net to profiles.

Miiverse uses https:// now (and redirects http:// URLs to the front page).

Also, it's nintendo.net now, not nintendo.com.

Just show "Battle.net" on the profile page.