### PR TITLE
don't render image decoration if url is falsey

### DIFF
--- a/app/assets/javascripts/sugar/rich_text.es6.jsx
+++ b/app/assets/javascripts/sugar/rich_text.es6.jsx
@@ -300,7 +300,7 @@
 
     addButton("Image", "picture", (s) => {
       let url = s.length > 0 ? s : prompt("Enter image URL", "");
-      return decorator().image(url);
+      return !!url ? decorator().image(url) : false;
     });
 
     addButton("Upload Image", "upload", (s) => {


### PR DESCRIPTION
**super** minor but if I hit cancel on the image button, sugar renders `<img src="null">`. This prevents that.