### PR TITLE
added news.twtr.plus to mastodon allowlist

### DIFF
--- a/config/initializers/oembed.rb
+++ b/config/initializers/oembed.rb
@@ -22,7 +22,8 @@ MASTODON_PROVIDERS = [
   "octodon.social",
   "ruby.social",
   "snabelen.no",
-  "techhub.social"
+  "techhub.social",
+  "news.twtr.plus"
 ].freeze
 
 MASTODON_PROVIDERS.each do |host|


### PR DESCRIPTION
one of the few mirror-bot networks i've found that seems to work/stay up to date