### PR TITLE
Read CACHE_DATABASE_URL for the production cache connection

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -71,8 +71,6 @@ production:
     password: <%= ENV["B3S_DATABASE_PASSWORD"] %>
   cache:
     <<: *default
-    database: b3s_cache
-    username: b3s
-    password: <%= ENV["B3S_DATABASE_PASSWORD"] %>
+    url: <%= ENV["CACHE_DATABASE_URL"] %>
     migrations_paths: db/cache_migrate
     schema_dump: cache_structure.sql


### PR DESCRIPTION
Deploy after #331 failed because the production `cache` connection had `database: b3s_cache, username: b3s, password: ENV["B3S_DATABASE_PASSWORD"]` and no `host:`. `B3S_DATABASE_PASSWORD` isn't set in production (DATABASE_URL is used instead), and Rails' auto-pickup of `CACHE_DATABASE_URL` doesn't override those explicit fields. Result: `db:prepare` ran `psql ... b3s_cache` with no host/user and fell through to a non-existent local socket.

Switch the cache block to read `CACHE_DATABASE_URL` explicitly via `url:`. The URL provides host/user/password/database directly.

Dev/test are unchanged — they connect via local socket / PG\* env vars and don't need a URL.
