### PR TITLE
Update rubocop and rubocop-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
-    minitest (6.0.5)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     mission_control-jobs (1.1.0)
@@ -386,7 +386,7 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
-    rubocop (1.86.1)
+    rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -410,7 +410,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.34.3)
+    rubocop-rails (2.35.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -667,7 +667,7 @@ CHECKSUMS
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
   mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.5) sha256=f007d7246bf4feea549502842cd7c6aba8851cdc9c90ba06de9c476c0d01155c
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   mission_control-jobs (1.1.0) sha256=b13da9cde3344fec7c744b79d2a34c3ecd454f45d4d593d4c968ba762315e84c
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
@@ -733,12 +733,12 @@ CHECKSUMS
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-rails (8.0.4) sha256=06235692fc0892683d3d34977e081db867434b3a24ae0dd0c6f3516bad4e22df
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
-  rubocop (1.86.1) sha256=44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531
+  rubocop (1.86.2) sha256=bb2e97f635eda42c448f2588f4a6ff78f221b8bdfdf65b1e9b07fbd57521b45d
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-capybara (2.23.0) sha256=f9ea1ba3a7561ee8e88cf76fc378ce517ce5327155f305ee7b5c2500e5aee357
   rubocop-factory_bot (2.28.0) sha256=4b17fc02124444173317e131759d195b0d762844a71a29fe8139c1105d92f0cb
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
-  rubocop-rails (2.34.3) sha256=10d37989024865ecda8199f311f3faca990143fbac967de943f88aca11eb9ad2
+  rubocop-rails (2.35.2) sha256=088865be9675922a5c8f13c00055a71ab768ea5eed211437cffd2a8b46b64ac2
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   rubocop-rspec_rails (2.32.0) sha256=4a0d641c72f6ebb957534f539d9d0a62c47abd8ce0d0aeee1ef4701e892a9100
   ruby-oembed (0.18.1) sha256=877b87b3d98e8137599044277fdb82a5536973bd9df68a93129163b781ae3a5f

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def current_section
-    params[:controller].to_sym
+    params.expect(:controller).to_sym
   end
 
   def current_user_context

--- a/app/controllers/conversation_participants_controller.rb
+++ b/app/controllers/conversation_participants_controller.rb
@@ -43,7 +43,7 @@ class ConversationParticipantsController < ApplicationController
   end
 
   def find_conversation
-    @conversation = Conversation.find(params[:conversation_id])
+    @conversation = Conversation.find(params.expect(:conversation_id))
     render_error 403 unless @conversation.viewable_by?(current_user)
   end
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -103,7 +103,7 @@ class ConversationsController < ApplicationController
   end
 
   def find_exchange
-    @exchange = Conversation.find(params[:id])
+    @exchange = Conversation.find(params.expect(:id))
     render_error 403 unless @exchange.viewable_by?(current_user)
   end
 

--- a/app/controllers/discussion_relationships_controller.rb
+++ b/app/controllers/discussion_relationships_controller.rb
@@ -39,7 +39,7 @@ class DiscussionRelationshipsController < ApplicationController
   private
 
   def find_discussion
-    @discussion = Discussion.find(params[:discussion_id])
+    @discussion = Discussion.find(params.expect(:discussion_id))
     render_error 403 unless @discussion.viewable_by?(current_user)
   end
 end

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -96,7 +96,7 @@ class DiscussionsController < ApplicationController
   end
 
   def current_section
-    params[:action].in?(%w[favorites following]) ? params[:action].to_sym : super
+    params.expect(:action).in?(%w[favorites following]) ? params.expect(:action).to_sym : super
   end
 
   def exchange_params
@@ -104,7 +104,7 @@ class DiscussionsController < ApplicationController
   end
 
   def find_exchange
-    @exchange = Exchange.find(params[:id])
+    @exchange = Exchange.find(params.expect(:id))
 
     if !@exchange.is_a?(Discussion)
       redirect_to @exchange

--- a/app/controllers/exchange_posts_controller.rb
+++ b/app/controllers/exchange_posts_controller.rb
@@ -93,7 +93,7 @@ class ExchangePostsController < ApplicationController
   end
 
   def find_post
-    @post = Post.find(params[:id])
+    @post = Post.find(params.expect(:id))
   end
 
   def post_params

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -80,7 +80,7 @@ class InvitesController < ApplicationController
   end
 
   def find_invite
-    @invite = Invite.find(params[:id])
+    @invite = Invite.find(params.expect(:id))
   end
 
   def find_invite_by_token

--- a/app/controllers/users/discussions_controller.rb
+++ b/app/controllers/users/discussions_controller.rb
@@ -23,7 +23,7 @@ module Users
 
     def load_user
       @user = User.find_by(username: params[:user_profile_id]) ||
-              User.find(params[:user_profile_id])
+              User.find(params.expect(:user_profile_id))
     end
   end
 end

--- a/app/controllers/users/invites_controller.rb
+++ b/app/controllers/users/invites_controller.rb
@@ -24,7 +24,7 @@ module Users
 
     def load_user
       @user = User.find_by(username: params[:user_id]) ||
-              User.find(params[:user_id])
+              User.find(params.expect(:user_id))
     end
   end
 end

--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -18,7 +18,7 @@ module Users
 
     def load_user
       @user = User.find_by(username: params[:user_profile_id]) ||
-              User.find(params[:user_profile_id])
+              User.find(params.expect(:user_profile_id))
     end
   end
 end

--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -53,7 +53,7 @@ module Users
 
     def load_user
       @user = User.find_by(username: params[:id]) ||
-              User.find(params[:id])
+              User.find(params.expect(:id))
     end
 
     def detect_edit_page

--- a/app/controllers/vanilla_controller.rb
+++ b/app/controllers/vanilla_controller.rb
@@ -12,7 +12,7 @@ class VanillaController < ApplicationController
   def discussion
     headers["Status"] = "301 Moved Permanently"
     redirect_to polymorphic_url(
-      Exchange.find(params[:DiscussionID]),
+      Exchange.find(params.expect(:DiscussionID)),
       page: params[:page]
     )
   end


### PR DESCRIPTION
Bumps rubocop 1.86.1→1.86.2 and rubocop-rails 2.34.3→2.35.2. The newer `Rails/StrongParametersExpect` flags `params[:key]` passed to raising finders, which autocorrected 14 occurrences across 12 controllers.