### PR TITLE
Add posts#show endpoint that redirects to post permalink

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,16 @@
 
 class PostsController < ApplicationController
   requires_authentication
-  requires_user
+  requires_user except: %i[show]
+
+  def show
+    post = Post.find(params.expect(:id))
+    raise ActiveRecord::RecordNotFound unless post.exchange.viewable_by?(current_user)
+
+    redirect_to polymorphic_url(post.exchange,
+                                page: post.page,
+                                anchor: "post-#{post.id}")
+  end
 
   def search
     @search_path = search_posts_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,9 +18,12 @@ Rails.application.routes.draw do
   get "/search/:query" => "discussions#search", as: :search_with_query
   match "/search" => "discussions#search", as: :search, via: %i[get post]
 
-  # Search posts
-  get "/posts/search/:query" => "posts#search"
-  match "/posts/search" => "posts#search", as: :search_posts, via: %i[get post]
+  # Posts
+  resources :posts, only: [:show], constraints: { id: /\d+/ } do
+    collection do
+      match "search(/:query)", action: :search, as: :search, via: %i[get post]
+    end
+  end
 
   # Sessions
   resource :session, only: %i[new create destroy]

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -32,4 +32,53 @@ RSpec.describe "Posts" do
       end
     end
   end
+
+  describe "GET /posts/:id" do
+    let(:exchange) { create(:discussion) }
+    let(:post_record) { create(:post, exchange:) }
+    let(:post_id) { post_record.id }
+
+    before { get post_path(post_id) }
+
+    it_behaves_like "authentication is required"
+
+    it "redirects to the post's permalink" do
+      expect(response).to redirect_to(
+        discussion_url(exchange, page: post_record.page,
+                                 anchor: "post-#{post_record.id}")
+      )
+    end
+
+    context "when the post does not exist" do
+      let(:post_id) { 999_999 }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+
+    context "when the post is in a conversation the user can see" do
+      let(:exchange) { create(:conversation) }
+      let(:post_record) { create(:post, exchange:, user: exchange.poster) }
+      let(:user) { exchange.poster }
+
+      it "redirects to the conversation permalink" do
+        expect(response).to redirect_to(
+          conversation_url(exchange, page: post_record.page,
+                                     anchor: "post-#{post_record.id}")
+        )
+      end
+    end
+
+    context "when the post is in a conversation the user cannot see" do
+      let(:exchange) { create(:conversation) }
+      let(:post_record) { create(:post, exchange:, user: exchange.poster) }
+
+      it "responds with not found" do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "does not reveal the conversation" do
+        expect(response).not_to be_redirect
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a `PostsController#show` endpoint so post permalinks can be a simple `/posts/:id` link instead of building the exchange path, page, and anchor at every call site.