### PR TITLE
Fix N+1 in Users::PostsController#index

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -29,7 +29,7 @@ class Post < ApplicationRecord
 
   scope :sorted,                 -> { order(:created_at) }
   scope :for_view,               -> { sorted.includes(user: [:avatar]) }
-  scope :for_view_with_exchange, -> { for_view.includes(:exchange) }
+  scope :for_view_with_exchange, -> { for_view.includes(exchange: :poster) }
 
   def me_post?
     body.strip =~ %r{^/me} && body.exclude?("\n")


### PR DESCRIPTION
Preload `exchange.poster` in `Post.for_view_with_exchange`. The user posts index renders each post with a title block that links to `post.exchange.poster`, which wasn't preloaded — one User query per post on the page. Also benefits `Post.search` results, which use the same scope.