### PR TITLE
Add local Dis cache layer in production

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -44,9 +44,10 @@ env:
     - QUEUE_DATABASE_URL
     - OEMBED_FACEBOOK_TOKEN
 
-# Persistent nginx image cache across deploys
+# Persistent caches across deploys
 volumes:
   - "b3s-nginx-cache:/var/cache/nginx"
+  - "b3s-dis-cache:/rails/storage/dis-cache"
 
 asset_path: /rails/public/assets
 

--- a/config/initializers/dis.rb
+++ b/config/initializers/dis.rb
@@ -11,6 +11,14 @@ if Rails.env.local?
   )
 end
 
+if Rails.env.production?
+  Dis::Storage.layers << Dis::Layer.new(
+    Fog::Storage.new(provider: "Local",
+                     local_root: Rails.root.join("storage/dis-cache")),
+    cache: 2.gigabytes
+  )
+end
+
 if Rails.application.credentials.aws
   Rails.application.credentials.tap do |credentials|
     Dis::Storage.layers << Dis::Layer.new(

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -6,6 +6,9 @@ production:
   cleanup_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(finished_before: 30.days.ago)"
     schedule: every day at 2am
+  evict_dis_cache:
+    class: Dis::Jobs::Evict
+    schedule: every day at 3am
 # production:
 #   periodic_cleanup:
 #     class: CleanSoftDeletedRecordsJob


### PR DESCRIPTION
Avatars and uploads were spending ~3.3s/request on synchronous S3 round-trips through the lone non-delayed Dis layer. Adds a 2 GB Fog::Local cache layer in front of S3 so reads hit local first and send_file can serve the real path instead of a tempfile copy. Persistent kamal volume + daily eviction job to keep size bounded (read-path backfills don't auto-evict).
