### PR TITLE
Reduce queries in Users::ProfilesController#show

### DIFF
--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -11,13 +11,7 @@ module Users
 
     def show
       respond_to do |format|
-        format.html do
-          @posts = @user.discussion_posts
-                        .viewable_by(current_user)
-                        .for_view_with_exchange
-                        .reverse_order
-                        .limit(15)
-        end
+        format.html { load_profile }
         format.json { render json: UserResource.new(@user) }
       end
     end
@@ -50,6 +44,25 @@ module Users
     end
 
     private
+
+    def load_profile
+      @posts = @user.discussion_posts
+                    .viewable_by(current_user)
+                    .for_view_with_exchange
+                    .reverse_order
+                    .limit(15)
+      @invitees = @user.invitees.to_a
+      load_profile_counts
+    end
+
+    def load_profile_counts
+      @discussions_count =
+        @user.discussions.viewable_by(current_user).count
+      @participated_discussions_count =
+        @user.participated_discussions.viewable_by(current_user).count
+      @discussion_posts_count =
+        @user.discussion_posts.viewable_by(current_user).count
+    end
 
     def load_user
       @user = User.find_by(username: params[:id]) ||

--- a/app/views/users/profiles/show.html+mobile.erb
+++ b/app/views/users/profiles/show.html+mobile.erb
@@ -103,7 +103,7 @@
       <th>Discussions</th>
 
       <td>
-        <%= link_to(@user.discussions.viewable_by(current_user).count,
+        <%= link_to(@discussions_count,
                     user_profile_discussions_path(@user.username)) %>
       </td>
     </tr>
@@ -112,7 +112,7 @@
       <th>Participated</th>
 
       <td>
-        <%= link_to(@user.participated_discussions.viewable_by(current_user).count,
+        <%= link_to(@participated_discussions_count,
                     participated_user_profile_discussions_path(@user.username)) %>
       </td>
     </tr>
@@ -121,13 +121,13 @@
       <th>Posts</th>
 
       <td>
-        <%= @user.discussion_posts.viewable_by(current_user).count %>
+        <%= @discussion_posts_count %>
       </td>
     </tr>
 
     <tr>
       <th>Users invited</th>
-      <td><%= @user.invitees.count %></td>
+      <td><%= @invitees.size %></td>
     </tr>
 
     <% if @user.previous_usernames.any? %>

--- a/app/views/users/profiles/show.html.erb
+++ b/app/views/users/profiles/show.html.erb
@@ -81,28 +81,28 @@
   <% end %>
 
   <p class="posts_and_discussions">
-    <% if @user.discussions.viewable_by(current_user).any? %>
+    <% if @discussions_count.positive? %>
       <%= link_to("View discussions",
                   user_profile_discussions_path( @user.username)) %>
       (
-      <%= @user.discussions.viewable_by(current_user).count %>
+      <%= @discussions_count %>
       )
       <br>
     <% end %>
 
-    <% if @user.participated_discussions.viewable_by(current_user).any? %>
+    <% if @participated_discussions_count.positive? %>
       <%= link_to("View participated discussions",
                   participated_user_profile_discussions_path( @user.username)) %>
       (
-      <%= @user.participated_discussions.viewable_by(current_user).count %>
+      <%= @participated_discussions_count %>
       )
       <br>
     <% end %>
 
-    <% if @user.discussion_posts.viewable_by(current_user).any? %>
+    <% if @discussion_posts_count.positive? %>
       <%= link_to "View posts", user_profile_posts_path( @user.username) %>
       (
-      <%= @user.discussion_posts.viewable_by(current_user).count %>
+      <%= @discussion_posts_count %>
       )
       <br>
     <% end %>
@@ -180,14 +180,14 @@
     <% end %>
   </div>
 
-  <% if @user.invitees.count > 0 %>
+  <% if @invitees.any? %>
     <div class="invitees">
       <h3>
-        <%= @user.username %> has invited <%= @user.invitees.count %> users:
+        <%= @user.username %> has invited <%= @invitees.size %> users:
       </h3>
 
       <ul>
-        <% @user.invitees.each do |invitee| %>
+        <% @invitees.each do |invitee| %>
           <li>
             <%= profile_link(invitee) %> (joined
             <%= time_tag invitee.created_at, class: "relative" %>)


### PR DESCRIPTION
Profile pages were issuing six `.any?` + `.count` queries for the discussion/participated/posts links and three for `@user.invitees`. Compute each count once in the controller and load `@invitees` as an array; the templates use the precomputed values.