### PR TITLE
Add partial GIN index on posts.tsv for global search

### DIFF
--- a/db/migrate/20260523170000_add_partial_gin_index_on_posts_tsv.rb
+++ b/db/migrate/20260523170000_add_partial_gin_index_on_posts_tsv.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddPartialGinIndexOnPostsTsv < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :posts, :tsv,
+              using: :gin,
+              where: "conversation = false AND deleted = false",
+              name: "index_posts_on_tsv_searchable",
+              algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1197,6 +1197,13 @@ CREATE INDEX index_posts_on_tsv ON public.posts USING gin (tsv);
 
 
 --
+-- Name: index_posts_on_tsv_searchable; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_tsv_searchable ON public.posts USING gin (tsv) WHERE ((conversation = false) AND (deleted = false));
+
+
+--
 -- Name: index_posts_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1308,9 +1315,10 @@ CREATE TRIGGER tsvectorupdate_posts BEFORE INSERT OR UPDATE ON public.posts FOR 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260523170000'),
+('20260514120000'),
 ('20260513213433'),
 ('20241117214337'),
-('20260514120000'),
 ('20241016075108'),
 ('20241016075107'),
 ('20241016075106'),


### PR DESCRIPTION
Global `PostsController#search` was averaging 12s and tailing to 33s — 100% DB-bound. The existing GIN index on `posts.tsv` doesn't pre-filter conversation/deleted rows, so the planner scans and rechecks a much larger candidate set than necessary before sorting by `created_at DESC LIMIT 50`.

Adds a partial GIN index matching the global-search predicate. Locally, `EXPLAIN ANALYZE` on `Post.search("colbert")` now picks `index_posts_on_tsv_searchable` and runs in ~12ms (was multi-second). The original `index_posts_on_tsv` is kept because `search_in_exchange` filters only `deleted`.
