### PR TITLE
Fix N+1 in Users::ListsController#index

### DIFF
--- a/app/controllers/users/lists_controller.rb
+++ b/app/controllers/users/lists_controller.rb
@@ -9,7 +9,7 @@ module Users
       respond_to do |format|
         format.html
         format.html.mobile { @online_users = @users.select(&:online?) }
-        format.json { render json: UserResource.new(@users) }
+        format.json { render json: UserResource.new(@users.includes(:user_links)) }
       end
     end
 
@@ -43,7 +43,7 @@ module Users
     def respond_with_users(users)
       respond_to do |format|
         format.html
-        format.json { render json: UserResource.new(users) }
+        format.json { render json: UserResource.new(users.includes(:user_links)) }
       end
     end
   end

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -9,5 +9,6 @@ class UserResource
              :last_active, :created_at, :description, :admin, :moderator,
              :user_admin, :location, :banned_until, :status
 
-  many :user_links, proc { |ul| ul.sorted }, resource: UserLinkResource
+  many :user_links, proc { |ul| ul.sort_by(&:position) },
+       resource: UserLinkResource
 end


### PR DESCRIPTION
`/users.json` was issuing ~256 queries because `UserResource` calls `ul.sorted` per user, forcing a fresh ORDER BY query even if user_links were preloaded. Preload `:user_links` in the controller and sort in Ruby in the resource — drops to ~3 queries.