### PR TITLE
Preload participants and posts in ConversationsController

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -10,15 +10,18 @@ class ConversationsController < ApplicationController
   before_action :find_recipient, only: [:create]
 
   def index
-    @exchanges = current_user.conversations.page(params[:page]).for_view
+    @exchanges = current_user.conversations
+                             .page(params[:page])
+                             .for_view
+                             .includes(:participants)
     respond_with_exchanges(@exchanges)
   end
 
   def show
     @page = params[:page] || 1
-    @posts = @exchange.posts.page(@page, context:).for_view
+    @posts = @exchange.posts.page(@page, context:).for_view.load
 
-    mark_as_viewed!(@exchange, @posts.last, @posts.offset_value + @posts.count)
+    mark_as_viewed!(@exchange, @posts.last, @posts.offset_value + @posts.size)
 
     respond_with_exchange(@exchange, @page)
 


### PR DESCRIPTION
Drops the N+1 in `#index` (`d.participants` per row in the table partial) by adding `includes(:participants)`. Loads the page relation up front in `#show` so `@posts.last` and the count don't fire extra queries.