### PR TITLE
Fix dis cache volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update -qq && \
     apt-get install --no-install-recommends -y \
-      curl libjemalloc2 libpq5 libvips42 nginx postgresql-client && \
+      curl gosu libjemalloc2 libpq5 libvips42 nginx postgresql-client && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
 
 ENV RAILS_ENV="production" \
@@ -86,10 +86,11 @@ FROM base
 RUN mkdir -p /var/cache/nginx/images /var/lib/nginx /var/log/nginx && \
     chown -R 1000:1000 /var/cache/nginx /var/lib/nginx /var/log/nginx /run
 
-# Run and own only the runtime files as a non-root user for security
+# Create the rails user. The entrypoint runs as root so it can fix
+# ownership on mounted volumes (e.g. the dis cache), then drops to
+# this user via gosu before exec-ing the app.
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash
-USER 1000:1000
 
 # Copy built artifacts: gems, application
 COPY --chown=rails:rails --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,5 +1,15 @@
 #!/bin/bash -e
 
+# Kamal named volumes mount as root:root by default. Fix ownership on
+# the writable paths the app expects before dropping to the rails user.
+if [ "$(id -u)" = "0" ]; then
+  for dir in /rails/storage/dis-cache; do
+    mkdir -p "$dir"
+    chown rails:rails "$dir"
+  done
+  exec gosu rails:rails "$0" "$@"
+fi
+
 # If running the web server then create or migrate existing database
 if [ "${1}" == "./bin/docker-start" ]; then
   ./bin/rails db:prepare


### PR DESCRIPTION
Hotfix for PR #353: the new `b3s-dis-cache` kamal volume mounts at `/rails/storage/dis-cache` owned by `root:root`, but the container runs as `rails` (uid 1000), so writes inside it fail with `Permission denied @ dir_s_mkdir`. All `/post_images/` and `/avatars/` cache-misses are currently 500ing in prod.

Drops the `USER 1000` directive so the entrypoint starts as root, chowns the cache dir, then re-execs itself as `rails` via `gosu`. Adds `gosu` to the runtime apt install.
