### PR TITLE
Fix dis cache volume permissions via pre-deploy hook

### DIFF
--- a/.kamal/hooks/pre-deploy
+++ b/.kamal/hooks/pre-deploy
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Ensure the b3s-dis-cache docker volume exists and is owned by the
+# rails user (uid 1000). Docker named volumes mount as root:root by
+# default, but the app container runs as uid 1000, so without this
+# the Dis local cache layer fails with EACCES on its first write.
+
+set -e
+
+echo "$KAMAL_HOSTS" | tr ',' '\n' | while read -r host; do
+  [ -z "$host" ] && continue
+  ssh -o BatchMode=yes "app@$host" '
+    docker volume inspect b3s-dis-cache >/dev/null 2>&1 \
+      || docker volume create b3s-dis-cache >/dev/null
+    docker run --rm -v b3s-dis-cache:/data alpine:3 \
+      chown -R 1000:1000 /data
+  '
+done

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update -qq && \
     apt-get install --no-install-recommends -y \
-      curl gosu libjemalloc2 libpq5 libvips42 nginx postgresql-client && \
+      curl libjemalloc2 libpq5 libvips42 nginx postgresql-client && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
 
 ENV RAILS_ENV="production" \
@@ -86,11 +86,10 @@ FROM base
 RUN mkdir -p /var/cache/nginx/images /var/lib/nginx /var/log/nginx && \
     chown -R 1000:1000 /var/cache/nginx /var/lib/nginx /var/log/nginx /run
 
-# Create the rails user. The entrypoint runs as root so it can fix
-# ownership on mounted volumes (e.g. the dis cache), then drops to
-# this user via gosu before exec-ing the app.
+# Run and own only the runtime files as a non-root user for security
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash
+USER 1000:1000
 
 # Copy built artifacts: gems, application
 COPY --chown=rails:rails --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,15 +1,5 @@
 #!/bin/bash -e
 
-# Kamal named volumes mount as root:root by default. Fix ownership on
-# the writable paths the app expects before dropping to the rails user.
-if [ "$(id -u)" = "0" ]; then
-  for dir in /rails/storage/dis-cache; do
-    mkdir -p "$dir"
-    chown rails:rails "$dir"
-  done
-  exec gosu rails:rails "$0" "$@"
-fi
-
 # If running the web server then create or migrate existing database
 if [ "${1}" == "./bin/docker-start" ]; then
   ./bin/rails db:prepare


### PR DESCRIPTION
PR #360 broke the deploy: starting the container as root and dropping to `rails` via `gosu` made nginx unable to reopen `/dev/stdout` for its access log (the underlying FD inode is root-owned, so the rails user gets EACCES on `open()`), and the health check timed out.

Reverts the Dockerfile and entrypoint changes from #360 (back to `USER 1000` with the original entrypoint), and instead fixes the `b3s-dis-cache` volume ownership from the host via a `pre-deploy` kamal hook — `docker run --rm -v b3s-dis-cache:/data alpine chown -R 1000:1000 /data`. Root access is naturally available on the host without touching the container's user model.

Idempotent: creates the volume if missing, chowns on every deploy.
