### PR TITLE
Make S3 dis layer delayed in production

### DIFF
--- a/config/initializers/dis.rb
+++ b/config/initializers/dis.rb
@@ -28,7 +28,7 @@ if Rails.application.credentials.aws
         aws_secret_access_key: credentials.dig(:aws, :secret_access_key)
       ),
       path: "b3s",
-      delayed: false,
+      delayed: Rails.env.production?,
       readonly: !Rails.env.production?
     )
   end


### PR DESCRIPTION
Now that the local Dis cache layer is in place (PR #353 + #361), flip the S3 layer to `delayed: true` in production. Uploads return as soon as the local cache write completes; `Dis::Jobs::Store` (queue `:dis`, Solid Queue picks up `*`) ships the file to S3 in the background. Should drop `UploadsController#create` from ~3.3s avg to whatever local disk + libvips validation costs.

Safe with the cache layer because `Dis::Storage.evict_cache` skips files that aren't yet replicated to a non-cache writeable layer (`storage.rb:291`) — a file pending the Store job won't be evicted.
