### PR TITLE
Reuse PostImage content_hash in uploads controller

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -20,15 +20,10 @@ class UploadsController < ApplicationController
 
   def find_or_create_post_image(file)
     post_image = PostImage.new(file:)
-    if post_image.valid?
-      hash = Dis::Storage.file_digest(file)
-      if PostImage.where(content_hash: hash).any?
-        post_image = PostImage.where(content_hash: hash).first
-      else
-        post_image.save
-      end
-    end
-    post_image
+    return post_image unless post_image.valid?
+
+    PostImage.find_by(content_hash: post_image.content_hash) ||
+      post_image.tap(&:save)
   end
 
   def post_image_response(post_image)


### PR DESCRIPTION
`PostImage.new(file:)` already computes `content_hash` via `Dis::Model#data=` (calls `Storage.file_digest(new_data.read)`). The explicit `Dis::Storage.file_digest(file)` call right after was a redundant second SHA1 pass over the upload, plus an extra query (`.where(...).any?` followed by `.where(...).first`). Reuse the hash already on the record.

Behavior unchanged: still record-level dedup so duplicate uploads return the same `PostImage.id` (keeps nginx's per-URL image cache effective).
