### PR TITLE
Fix N+1 in UserLinksController

### DIFF
--- a/app/controllers/user_links_controller.rb
+++ b/app/controllers/user_links_controller.rb
@@ -6,6 +6,7 @@ class UserLinksController < ApplicationController
 
   def all
     @labels = UserLink.labels
+    @counts = UserLink.active.group("lower(user_links.label)").count
   end
 
   def index
@@ -14,6 +15,7 @@ class UserLinksController < ApplicationController
                  .joins(:user_links)
                  .where("lower(user_links.label) LIKE lower(?)", @label)
                  .group("users.id")
+                 .preload(:user_links)
   end
 
   private

--- a/app/views/user_links/all.html+mobile.erb
+++ b/app/views/user_links/all.html+mobile.erb
@@ -14,7 +14,7 @@
       </td>
 
       <td>
-        <%= UserLink.active.with_label(label).count %>
+        <%= @counts[label.downcase] || 0 %>
       </td>
     </tr>
   <% end %>

--- a/app/views/user_links/all.html.erb
+++ b/app/views/user_links/all.html.erb
@@ -21,7 +21,7 @@
       </td>
 
       <td>
-        <%= UserLink.active.with_label(label).count %>
+        <%= @counts[label.downcase] || 0 %>
       </td>
     </tr>
   <% end %>

--- a/app/views/user_links/index.html+mobile.erb
+++ b/app/views/user_links/index.html+mobile.erb
@@ -15,7 +15,7 @@
 
       <td class="user-links">
         <ul>
-          <% user.user_links.sorted.with_label(@label).each do |ul| %>
+          <% user.user_links.select { |ul| ul.label.casecmp?(@label) }.sort_by(&:position).each do |ul| %>
             <li>
               <%= user_link(ul) %>
             </li>

--- a/app/views/user_links/index.html.erb
+++ b/app/views/user_links/index.html.erb
@@ -23,7 +23,7 @@
 
       <td class="user-links">
         <ul>
-          <% user.user_links.sorted.with_label(@label).each do |ul| %>
+          <% user.user_links.select { |ul| ul.label.casecmp?(@label) }.sort_by(&:position).each do |ul| %>
             <li>
               <%= user_link(ul) %>
             </li>


### PR DESCRIPTION
`#index` preloads `:user_links` and filters/sorts the label match in Ruby; `#all` computes label counts in one grouped query. Drops both from ~22 to ~4 queries on populated data.