### PR TITLE
Load @posts up front in DiscussionsController#show

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -43,9 +43,9 @@ class DiscussionsController < ApplicationController
 
   def show
     @page = params[:page] || 1
-    @posts = @exchange.posts.page(@page, context:).for_view
+    @posts = @exchange.posts.page(@page, context:).for_view.load
 
-    mark_as_viewed!(@exchange, @posts.last, @posts.offset_value + @posts.count)
+    mark_as_viewed!(@exchange, @posts.last, @posts.offset_value + @posts.size)
 
     respond_with_exchange(@exchange, @page)
   end


### PR DESCRIPTION
Mirrors PR #358 for ConversationsController. Avoids an extra `SELECT COUNT(*)` on the limited/offset relation by loading the page eagerly and using `@posts.size`.