### PR TITLE
Scope position-keyed pagination to discussion views

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -19,7 +19,7 @@ class ConversationsController < ApplicationController
 
   def show
     @page = params[:page] || 1
-    @posts = @exchange.posts.page(@page, context:, total_count: @exchange.posts_count).for_view.load
+    @posts = @exchange.posts.paginate_by_position(@page, context:, total_count: @exchange.posts_count).for_view.load
 
     mark_as_viewed!(@exchange, @posts.last, @posts.last&.position || 0)
 

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -43,7 +43,7 @@ class DiscussionsController < ApplicationController
 
   def show
     @page = params[:page] || 1
-    @posts = @exchange.posts.page(@page, context:, total_count: @exchange.posts_count).for_view.load
+    @posts = @exchange.posts.paginate_by_position(@page, context:, total_count: @exchange.posts_count).for_view.load
 
     mark_as_viewed!(@exchange, @posts.last, @posts.last&.position || 0)
 

--- a/app/models/concerns/paginatable/position_keyed.rb
+++ b/app/models/concerns/paginatable/position_keyed.rb
@@ -5,56 +5,95 @@ module Paginatable
     extend ActiveSupport::Concern
 
     module Pagination
-      attr_writer :pagination_offset
+      attr_writer :pagination_offset, :context
 
       def pagination_offset
         @pagination_offset || 0
       end
-    end
 
-    module ClassMethods
-      def page(page = nil, options = {})
-        page_num = [page.to_i, 1].max
-        context = page_num > 1 ? options[:context].to_i : 0
-        position_range = page_position_range(page_num, context)
-        paginate_by_position(position_range, context, page_num,
-                             options[:total_count])
+      def context
+        @context || 0
+      end
+
+      def pagination_memo
+        @pagination_memo ||= {}
       end
 
       def current_page
-        scope = all
-        return 1 unless scope.respond_to?(:pagination_memo)
-
-        scope.pagination_memo[:current_page] || 1
+        pagination_memo[:current_page] || 1
       end
 
       def total_pages
-        (max_position.to_f / pagination_limit).ceil
+        (max_position.to_f / klass.per_page).ceil
+      end
+
+      def first_page
+        1
+      end
+
+      def last_page
+        total_pages
+      end
+
+      def first_page?
+        current_page == first_page
+      end
+
+      def last_page?
+        current_page == last_page
+      end
+
+      def previous_page
+        current_page - 1 if current_page > 1
+      end
+
+      def next_page
+        current_page + 1 if current_page < total_pages
+      end
+
+      def total_count
+        return pagination_memo[:total_count] if pagination_memo.key?(:total_count)
+
+        value = unscope(where: :position)
+                .except(:limit, :offset, :order, :includes)
+                .count
+        value = value.length if value.is_a?(Hash)
+        pagination_memo[:total_count] = value
+        value
       end
 
       private
 
       def max_position
-        scope = all
-        memo = scope.respond_to?(:pagination_memo) ? scope.pagination_memo : nil
-        return memo[:max_position] if memo&.key?(:max_position)
+        return pagination_memo[:max_position] if pagination_memo.key?(:max_position)
 
-        value = scope.unscope(where: :position).maximum(:position) || 0
-        memo[:max_position] = value if memo
+        value = unscope(where: :position).maximum(:position) || 0
+        pagination_memo[:max_position] = value
         value
       end
+    end
 
-      def page_position_range(page_num, context)
-        first = ((page_num - 1) * pagination_limit) + 1 - context
-        first..(page_num * pagination_limit)
+    module ClassMethods
+      def paginate_by_position(page = nil, options = {})
+        page_num = [page.to_i, 1].max
+        context = page_num > 1 ? options[:context].to_i : 0
+        range = position_range_for_page(page_num, context)
+        scope_for_position_page(range, context, page_num, options[:total_count])
       end
 
-      def paginate_by_position(range, context, page_num, total_count)
-        scope = scope_with_context(context, total_count:)
-                .where(position: range)
-                .extending(Pagination)
+      private
+
+      def position_range_for_page(page_num, context)
+        first = ((page_num - 1) * per_page) + 1 - context
+        first..(page_num * per_page)
+      end
+
+      def scope_for_position_page(range, context, page_num, total_count)
+        scope = where(position: range).extending(Pagination)
         scope.pagination_offset = range.first - 1
+        scope.context = context
         scope.pagination_memo[:current_page] = page_num
+        scope.pagination_memo[:total_count] = total_count unless total_count.nil?
         scope
       end
     end

--- a/spec/models/concerns/paginatable/position_keyed_spec.rb
+++ b/spec/models/concerns/paginatable/position_keyed_spec.rb
@@ -12,60 +12,64 @@ describe Paginatable::PositionKeyed do
 
   after { Post.per_page = 50 }
 
-  describe ".page" do
+  describe ".paginate_by_position" do
     it "selects posts via WHERE position BETWEEN" do
-      expect(exchange.posts.page(2).to_sql)
+      expect(exchange.posts.paginate_by_position(2).to_sql)
         .to include(%("posts"."position" BETWEEN 6 AND 10))
     end
 
     it "does not generate an OFFSET clause" do
-      expect(exchange.posts.page(2).to_sql).not_to match(/OFFSET/i)
+      expect(exchange.posts.paginate_by_position(2).to_sql).not_to match(/OFFSET/i)
     end
 
     it "returns the page's worth of posts" do
-      page2 = exchange.posts.page(2).load
+      page2 = exchange.posts.paginate_by_position(2).load
       expect(page2.map(&:position)).to eq([6, 7, 8, 9, 10])
     end
 
     it "includes context rows on pages after the first" do
-      page2 = exchange.posts.page(2, context: 2).load
+      page2 = exchange.posts.paginate_by_position(2, context: 2).load
       expect(page2.map(&:position)).to eq([4, 5, 6, 7, 8, 9, 10])
     end
 
     it "ignores context on page 1" do
-      page1 = exchange.posts.page(1, context: 2).load
+      page1 = exchange.posts.paginate_by_position(1, context: 2).load
       expect(page1.map(&:position)).to eq([1, 2, 3, 4, 5])
     end
 
     it "clamps page < 1 to page 1" do
-      page0 = exchange.posts.page(0).load
+      page0 = exchange.posts.paginate_by_position(0).load
       expect(page0.map(&:position)).to eq([1, 2, 3, 4, 5])
     end
 
     it "returns no rows past the last page" do
-      expect(exchange.posts.page(99).load).to be_empty
+      expect(exchange.posts.paginate_by_position(99).load).to be_empty
+    end
+
+    it "does not affect the default offset-based .page" do
+      expect(exchange.posts.page(2).to_sql).to match(/OFFSET/i)
     end
   end
 
-  describe ".current_page" do
-    specify { expect(exchange.posts.page(1).current_page).to eq(1) }
-    specify { expect(exchange.posts.page(2).current_page).to eq(2) }
+  describe "#current_page" do
+    specify { expect(exchange.posts.paginate_by_position(1).current_page).to eq(1) }
+    specify { expect(exchange.posts.paginate_by_position(2).current_page).to eq(2) }
   end
 
-  describe ".total_pages" do
+  describe "#total_pages" do
     it "derives from MAX(position), ignoring any seeded total_count" do
-      scope = exchange.posts.page(1, total_count: 100)
+      scope = exchange.posts.paginate_by_position(1, total_count: 100)
       expect(scope.total_pages).to eq(2)
     end
   end
 
-  describe ".pagination_offset" do
+  describe "#pagination_offset" do
     it "reports the row count skipped before the page" do
-      expect(exchange.posts.page(2).pagination_offset).to eq(5)
+      expect(exchange.posts.paginate_by_position(2).pagination_offset).to eq(5)
     end
 
     it "subtracts context from the offset on pages after the first" do
-      expect(exchange.posts.page(2, context: 2).pagination_offset).to eq(3)
+      expect(exchange.posts.paginate_by_position(2, context: 2).pagination_offset).to eq(3)
     end
   end
 end


### PR DESCRIPTION
Position-keyed pagination was overriding `Post.page` globally, breaking pagination for search-all-posts, in-discussion search, and a user's posts. Made it opt-in as `paginate_by_position` and called from the discussion and conversation show actions only.