### PR TITLE
Raise statistics target on posts.tsv to 5000

### DIFF
--- a/db/migrate/20260525200000_raise_statistics_target_on_posts_tsv.rb
+++ b/db/migrate/20260525200000_raise_statistics_target_on_posts_tsv.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RaiseStatisticsTargetOnPostsTsv < ActiveRecord::Migration[8.1]
+  def up
+    execute "ALTER TABLE posts ALTER COLUMN tsv SET STATISTICS 5000"
+    execute "ANALYZE posts"
+  end
+
+  def down
+    execute "ALTER TABLE posts ALTER COLUMN tsv SET STATISTICS DEFAULT"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -508,6 +508,7 @@ CREATE TABLE public.posts (
     tsv tsvector,
     "position" integer NOT NULL
 );
+ALTER TABLE ONLY public.posts ALTER COLUMN tsv SET STATISTICS 5000;
 
 
 --
@@ -1323,6 +1324,7 @@ CREATE TRIGGER tsvectorupdate_posts BEFORE INSERT OR UPDATE ON public.posts FOR 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260525200000'),
 ('20260524080100'),
 ('20260524080000'),
 ('20260523200000'),


### PR DESCRIPTION
Lets the planner see frequencies for the top ~5000 lexemes instead of ~100, so it stops over-trusting scan-backward on `index_posts_on_created_at` for terms that look common globally but are sparse in recent data. In dev that knocked the worst-case search (many old matches, none recent) from ~300ms to ~170ms with no regression on common terms.

`ANALYZE posts` runs inside the migration. Only takes `ShareUpdateExclusiveLock` — doesn't block reads or writes.