### PR TITLE
Guard LinkFilter against malformed URLs

### DIFF
--- a/app/filters/link_filter.rb
+++ b/app/filters/link_filter.rb
@@ -47,24 +47,30 @@ class LinkFilter < Filter
     @parser ||= Nokogiri::HTML::DocumentFragment.parse(@post)
   end
 
+  def safe_uri_parse(url)
+    URI.parse(url)
+  rescue URI::InvalidURIError
+    nil
+  end
+
   def matches_https_whitelist?(url)
-    host = URI.parse(url).host
+    host = safe_uri_parse(url)&.host
     return false unless host
 
     HTTPS_WHITELIST.detect { |domain| File.fnmatch(domain, host) }
   end
 
   def https_url_exists?(url)
-    uri = URI.parse(url.gsub(%r{^(https?:)//}, "https://"))
-    begin
-      head_request(uri) =~ /^(2|3)\d\d$/
-    rescue SocketError, Net::OpenTimeout,
-           OpenSSL::SSL::SSLError, Errno::ECONNREFUSED
-      false
-    rescue StandardError => e
-      logger.error "Unexpected connection error #{e.inspect}"
-      false
-    end
+    uri = safe_uri_parse(url.gsub(%r{^(https?:)//}, "https://"))
+    return false unless uri
+
+    head_request(uri) =~ /^(2|3)\d\d$/
+  rescue SocketError, Net::OpenTimeout,
+         OpenSSL::SSL::SSLError, Errno::ECONNREFUSED
+    false
+  rescue StandardError => e
+    logger.error "Unexpected connection error #{e.inspect}"
+    false
   end
 
   def relativize_local_links!
@@ -72,7 +78,7 @@ class LinkFilter < Filter
       href = extract_href(link)
       next unless href&.match?(%r{^https?://})
 
-      host = URI.parse(href).host
+      host = safe_uri_parse(href)&.host
       next unless local_domain?(host)
 
       link.set_attribute(

--- a/spec/filters/link_filter_spec.rb
+++ b/spec/filters/link_filter_spec.rb
@@ -16,6 +16,26 @@ describe LinkFilter do
     end
   end
 
+  context "when input contains a malformed link" do
+    before { B3S.config.domain_names = "b3s.me" }
+
+    let(:input) { %(<a href="http://www.example.com/>foo&amp;bar">x</a>) }
+    let(:output) { %(<a href="http://www.example.com/&gt;foo&amp;bar">x</a>) }
+
+    it "leaves the link untouched" do
+      expect(filter.to_html).to eq(output)
+    end
+  end
+
+  context "when input contains a malformed image src" do
+    let(:input) { %(<img src="http://www.example.com/>foo&amp;bar">) }
+    let(:output) { %(<img src="http://www.example.com/&gt;foo&amp;bar">) }
+
+    it "leaves the image untouched" do
+      expect(filter.to_html).to eq(output)
+    end
+  end
+
   context "when input contains an image on the HTTPS whitelist" do
     let(:input) { '<img src="http://i.imgur.com/test.gif">' }
     let(:output) { '<img src="//i.imgur.com/test.gif">' }


### PR DESCRIPTION
URI.parse blew up on a post containing a malformed link, taking down PostsController#search. Skip rewriting when the URL can't be parsed.

Fixes B3S-AD